### PR TITLE
fix: use aln not bam in input to whatshap_haplotag

### DIFF
--- a/workflow/rules/whatshap.smk
+++ b/workflow/rules/whatshap.smk
@@ -38,7 +38,7 @@ rule whatshap_phase:
 
 rule whatshap_haplotag:
     input:
-        bam=lambda wildcards: get_input_bam(wildcards)[0],
+        aln=lambda wildcards: get_input_bam(wildcards)[0],
         bai=lambda wildcards: get_input_bam(wildcards)[1],
         ref=config.get("reference", {}).get("fasta", ""),
         fai=config.get("reference", {}).get("fai", ""),
@@ -65,6 +65,6 @@ rule whatshap_haplotag:
     container:
         config.get("whatshap_haplotag", {}).get("container", config["default_container"])
     message:
-        "{rule}: do haplotagging on {input.bam}"
+        "{rule}: do haplotagging on {input.aln}"
     wrapper:
         "v6.0.0/bio/whatshap/haplotag"

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -891,7 +891,7 @@ properties:
           vcf:
             type: string
             description: phased variants in VCF format
-          bam:
+          aln:
             type: string
             description: BAM file with reads to haplotag
           bai:


### PR DESCRIPTION
input.aln (not input.bam) is required by the wrapper

### This PR:

Fixed: change input name from bam to aln

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
