### PR TITLE
fix: change callers name to clairs_to in fix_af.py

### DIFF
--- a/workflow/scripts/fix_af.py
+++ b/workflow/scripts/fix_af.py
@@ -83,7 +83,6 @@ def writeNewVcf(path: str, header: pysam.libcbcf.VariantHeader, vcf: pysam.libcb
             row.samples[0]["AF"] = row.samples[0].get("VAF")
         elif caller == "clairs_to":
             row.info["AF"] = row.samples[0].get("AF")
-            row.samples[0]["AF"] = row.samples[0].get("AF")
         elif caller == "gatk_select_variants_final":
             row.info["AF"] = row.samples[0].get("AF")
         elif caller == "varscan":


### PR DESCRIPTION
add clairs_to to acceptable caller names

### This PR:

Fixed: if caller is clairs_to the script will fix AF correctly.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
