### PR TITLE
feat: possibility to speedup GATK calling by generating vcf from gvcf

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: pip install -r requirements.txt
       - name: Linting
         working-directory: .tests/integration
-        run: snakemake --lint -n -s ../../workflow/Snakefile --configfile config.yaml
+        run: snakemake --lint -n -s Snakefile.test --configfile config.yaml
 
   pycodestyle:
     name: pycodestyle
@@ -103,7 +103,7 @@ jobs:
           pip install -r requirements.txt
       - name: Snakemake dry run short read
         working-directory: .tests/integration
-        run: snakemake -n -s ../../workflow/Snakefile --configfile config.yaml
+        run: snakemake -n -s Snakefile.test all --configfile config.yaml
       - name: Snakemake dry run short read deepvariant
         working-directory: .tests/integration
         run: snakemake -n -s ../../workflow/Snakefile --configfile config_deepvariant.yaml
@@ -211,7 +211,7 @@ jobs:
         working-directory: .tests/integration
         run: |
           mkdir -p ~/singularity_containers &&
-          snakemake -s ../../workflow/Snakefile -j 4 --show-failed-logs --configfile config.yaml --use-singularity --singularity-args " --cleanenv --bind /home/runner " --singularity-prefix ~/singularity_containers/
+          snakemake -s Snakefile.test all -j 4 --show-failed-logs --configfile config.yaml --use-singularity --singularity-args " --cleanenv --bind /home/runner " --singularity-prefix ~/singularity_containers/
       - name: Integration test - short read deepvariant
         working-directory: .tests/integration
         run: |

--- a/.tests/compatibility/Snakefile
+++ b/.tests/compatibility/Snakefile
@@ -44,3 +44,10 @@ module snv_indels:
 
 
 use rule * from snv_indels as snv_indels_*
+
+
+# gatk_mutect2 and gatk_selectvariants_gvcf_to_vcf both produce
+# snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.{vcf.gz,vcf.gz.tbi,vcf.gz.stats,bam,bai} -
+# the module takes no default stance, so every consumer must declare its own
+# preference. This mirrors the default (non-speedup) behavior.
+ruleorder: snv_indels_gatk_mutect2 > snv_indels_gatk_selectvariants_gvcf_to_vcf

--- a/.tests/integration/Snakefile.test
+++ b/.tests/integration/Snakefile.test
@@ -1,0 +1,9 @@
+include: "../../workflow/Snakefile"
+
+
+# gatk_mutect2 and gatk_selectvariants_gvcf_to_vcf both produce
+# snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.{vcf.gz,vcf.gz.tbi,vcf.gz.stats,bam,bai} -
+# the module itself takes no default stance (see gatk_selectvariants_gvcf_to_vcf's
+# docstring in workflow/rules/gatk.smk), so every consumer, including this test,
+# must declare its own preference. This mirrors the default (non-speedup) behavior.
+ruleorder: gatk_mutect2 > gatk_selectvariants_gvcf_to_vcf

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -508,6 +508,29 @@ Mutect2 is used to generate a genome vcf file containing allele information for 
 
 ---
 
+## [gatk_selectvariants_gvcf_to_vcf](https://gatk.broadinstitute.org/hc/en-us/articles/360037052712-SelectVariants)
+Extracts variant-only sites from a Mutect2 gVCF, replacing a separate VCF-mode Mutect2 call and saving approximately half the Mutect2 compute time. The Mutect2 stats file is passed through from the gVCF run so that downstream filtering steps (`gatk_mutect2_merge_stats`, `gatk_mutect2_filter`) continue to work unchanged. Activate in a pipeline with `ruleorder: gatk_selectvariants_gvcf_to_vcf > gatk_mutect2`.
+
+### :snake: Rule
+
+#SNAKEMAKE_RULE_SOURCE__gatk__gatk_selectvariants_gvcf_to_vcf#
+
+#### :left_right_arrow: input / output files
+
+#SNAKEMAKE_RULE_TABLE__gatk__gatk_selectvariants_gvcf_to_vcf#
+
+### :wrench: Configuration
+
+#### Software settings (`config.yaml`)
+
+#CONFIGSCHEMA__gatk_selectvariants_gvcf_to_vcf#
+
+#### Resources settings (`resources.yaml`)
+
+#RESOURCESSCHEMA__gatk_selectvariants_gvcf_to_vcf#
+
+---
+
 ## [gatk_mutect2_filter](https://gatk.broadinstitute.org/hc/en-us/articles/13832710384155-Mutect2)
 Step 3 of 4 of Mutect2 variant calling filtering the called variants using the merged statistics file.
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -36,11 +36,12 @@ ruleorder: clairs_to_call > bgzip
 ruleorder: clairs_to_concat > bgzip
 ruleorder: deepsomatic_t_only > bgzip
 ruleorder: deepsomatic_tn > bgzip
-#ruleorder: gatk_mutect2 > gatk_selectvariants_gvcf_to_vcf
 ruleorder: gatk_mutect2 > bgzip
 ruleorder: gatk_mutect2 > tabix
 ruleorder: gatk_mutect2_gvcf > bgzip
 ruleorder: gatk_mutect2_gvcf > tabix
+ruleorder: gatk_selectvariants_gvcf_to_vcf > bgzip
+ruleorder: gatk_selectvariants_gvcf_to_vcf > tabix
 ruleorder: gatk_mutect2_filter > bgzip
 ruleorder: mutect2_pass_filter > bgzip
 ruleorder: vt_decompose > bgzip

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -36,7 +36,7 @@ ruleorder: clairs_to_call > bgzip
 ruleorder: clairs_to_concat > bgzip
 ruleorder: deepsomatic_t_only > bgzip
 ruleorder: deepsomatic_tn > bgzip
-ruleorder: gatk_mutect2 > gatk_selectvariants_gvcf_to_vcf
+#ruleorder: gatk_mutect2 > gatk_selectvariants_gvcf_to_vcf
 ruleorder: gatk_mutect2 > bgzip
 ruleorder: gatk_mutect2 > tabix
 ruleorder: gatk_mutect2_gvcf > bgzip

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -36,6 +36,7 @@ ruleorder: clairs_to_call > bgzip
 ruleorder: clairs_to_concat > bgzip
 ruleorder: deepsomatic_t_only > bgzip
 ruleorder: deepsomatic_tn > bgzip
+ruleorder: gatk_mutect2 > gatk_selectvariants_gvcf_to_vcf
 ruleorder: gatk_mutect2 > bgzip
 ruleorder: gatk_mutect2 > tabix
 ruleorder: gatk_mutect2_gvcf > bgzip

--- a/workflow/rules/gatk.smk
+++ b/workflow/rules/gatk.smk
@@ -48,6 +48,8 @@ rule gatk_mutect2_gvcf:
         fasta=config.get("reference", {}).get("fasta", ""),
         bed="snv_indels/bed_split/design_bedfile_{chr}.bed",
     output:
+        bam=temp("snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.bam"),
+        bai=temp("snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.bai"),
         stats=temp("snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz.stats"),
         vcf=temp("snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz"),
         tbi=temp("snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz.tbi"),
@@ -77,9 +79,10 @@ rule gatk_mutect2_gvcf:
 
 rule gatk_selectvariants_gvcf_to_vcf:
     """Extract variant-only sites from a Mutect2 gVCF, replacing a separate
-    VCF-mode Mutect2 call. The gVCF stats are passed through unchanged so that
-    downstream gatk_mutect2_merge_stats / gatk_mutect2_filter rules continue to
-    work without modification.
+    VCF-mode Mutect2 call. The gVCF stats and the locally reassembled bam are
+    passed through unchanged so that downstream gatk_mutect2_merge_stats /
+    gatk_mutect2_filter / alignment_samtools_merge_bam_mutect2-style rules
+    continue to work without modification.
 
     Enable in a pipeline with:
         ruleorder: gatk_selectvariants_gvcf_to_vcf > gatk_mutect2
@@ -88,11 +91,15 @@ rule gatk_selectvariants_gvcf_to_vcf:
         gvcf="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz",
         tbi="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz.tbi",
         stats="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz.stats",
+        bam="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.bam",
+        bai="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.bai",
         fasta=config.get("reference", {}).get("fasta", ""),
     output:
         vcf=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz"),
         tbi=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz.tbi"),
         stats=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz.stats"),
+        bam=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.bam"),
+        bai=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.bai"),
     params:
         extra=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("extra", "--exclude-non-variants --remove-unused-alternates"),
     log:
@@ -119,6 +126,8 @@ rule gatk_selectvariants_gvcf_to_vcf:
         """
         gatk SelectVariants -R {input.fasta} -V {input.gvcf} -O {output.vcf} {params.extra} 2> {log}
         cp {input.stats} {output.stats}
+        cp {input.bam} {output.bam}
+        cp {input.bai} {output.bai}
         """
 
 

--- a/workflow/rules/gatk.smk
+++ b/workflow/rules/gatk.smk
@@ -75,6 +75,53 @@ rule gatk_mutect2_gvcf:
         "v1.5.0/bio/gatk/mutect"
 
 
+rule gatk_selectvariants_gvcf_to_vcf:
+    """Extract variant-only sites from a Mutect2 gVCF, replacing a separate
+    VCF-mode Mutect2 call. The gVCF stats are passed through unchanged so that
+    downstream gatk_mutect2_merge_stats / gatk_mutect2_filter rules continue to
+    work without modification.
+
+    Enable in a pipeline with:
+        ruleorder: gatk_selectvariants_gvcf_to_vcf > gatk_mutect2
+    """
+    input:
+        gvcf="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz",
+        tbi="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz.tbi",
+        stats="snv_indels/gatk_mutect2_gvcf/{sample}_{type}_{chr}.g.vcf.gz.stats",
+        fasta=config.get("reference", {}).get("fasta", ""),
+    output:
+        vcf=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz"),
+        tbi=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz.tbi"),
+        stats=temp("snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz.stats"),
+    params:
+        extra=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("extra", "--exclude-non-variants --remove-unused-alternates"),
+    log:
+        "snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz.selectvariants.log",
+    benchmark:
+        repeat(
+            "snv_indels/gatk_mutect2/{sample}_{type}_{chr}.unfiltered.vcf.gz.selectvariants.benchmark.tsv",
+            config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("benchmark_repeats", 1),
+        )
+    threads: config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("threads", config["default_resources"]["threads"])
+    resources:
+        mem_mb=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
+        mem_per_cpu=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get(
+            "mem_per_cpu", config["default_resources"]["mem_per_cpu"]
+        ),
+        partition=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("partition", config["default_resources"]["partition"]),
+        threads=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("threads", config["default_resources"]["threads"]),
+        time=config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("time", config["default_resources"]["time"]),
+    container:
+        config.get("gatk_selectvariants_gvcf_to_vcf", {}).get("container", config["default_container"])
+    message:
+        "{rule}: extract variants from gVCF {input.gvcf}"
+    shell:
+        """
+        gatk SelectVariants -R {input.fasta} -V {input.gvcf} -O {output.vcf} {params.extra} 2> {log}
+        cp {input.stats} {output.stats}
+        """
+
+
 rule gatk_mutect2_filter:
     input:
         vcf="snv_indels/gatk_mutect2/{sample}_{type}.merged.unfiltered.vcf.gz",

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -397,6 +397,20 @@ properties:
         type: string
         description: parameters that should be forwarded
 
+  gatk_selectvariants_gvcf_to_vcf:
+    type: object
+    description: parameters for gatk_selectvariants_gvcf_to_vcf — extracts variant-only sites from a Mutect2 gVCF, replacing a separate gatk_mutect2 VCF-mode call. Activate with ruleorder gatk_selectvariants_gvcf_to_vcf > gatk_mutect2.
+    properties:
+      benchmark_repeats:
+        type: integer
+        description: set number of times benchmark should be repeated
+      container:
+        type: string
+        description: name or path to docker/singularity container
+      extra:
+        type: string
+        description: additional SelectVariants parameters (default -- exclude-non-variants --remove-unused-alternates)
+
   gatk_mutect2_merge_stats:
     type: object
     description: parameters for gatk_mutect2_merge_stats

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -510,6 +510,26 @@ properties:
         type: string
         description: max execution time
 
+  gatk_selectvariants_gvcf_to_vcf:
+    type: object
+    description: resource definitions for gatk_selectvariants_gvcf_to_vcf
+    properties:
+      mem_mb:
+        type: integer
+        description: max memory in MB to be available
+      mem_per_cpu:
+        type: integer
+        description: memory in MB used per cpu
+      partition:
+        type: string
+        description: partition to use on cluster
+      threads:
+        type: integer
+        description: number of threads to be available
+      time:
+        type: string
+        description: max execution time
+
   gatk_mutect2_merge_stats:
     type: object
     description: resource definitions for gatk_mutect2_merge_stats

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -575,6 +575,40 @@ properties:
             type: string
             description: tabix file index (`.g.vcf.gz.tbi`)
 
+  gatk_selectvariants_gvcf_to_vcf:
+    type: object
+    description: input and output parameters for gatk_selectvariants_gvcf_to_vcf
+    properties:
+      input:
+        type: object
+        description: list of inputs
+        properties:
+          gvcf:
+            type: string
+            description: compressed gVCF produced by gatk_mutect2_gvcf
+          tbi:
+            type: string
+            description: tabix index for the gVCF
+          stats:
+            type: string
+            description: Mutect2 stats file produced alongside the gVCF
+          fasta:
+            type: string
+            description: fasta reference genome file
+      output:
+        type: object
+        description: list of outputs
+        properties:
+          vcf:
+            type: string
+            description: compressed VCF containing only variant sites extracted from the gVCF (same path as gatk_mutect2 output)
+          tbi:
+            type: string
+            description: tabix index for the VCF
+          stats:
+            type: string
+            description: Mutect2 stats file passed through from the gVCF run (same path as gatk_mutect2 stats output)
+
   gatk_mutect2_filter:
     type: object
     description: input and output parameters for gatk_mutect2_filter


### PR DESCRIPTION
Mutect2 can not generate both gcvf and vcf in one step so this is now run twice. 
To speed this up, the gvcf can be run first and then the vcf is extracted afterwards. 
This PR introduces and option to chose this faster strategy instead while keeping the backwards compatibility. Tested successfully on the GMS_Solid pipeline.